### PR TITLE
Add options from newer versions to CMP_CompressOptions.cs

### DIFF
--- a/Structs/CMP_CompressOptions.cs
+++ b/Structs/CMP_CompressOptions.cs
@@ -16,6 +16,30 @@ namespace Compressonator.NET
         [MarshalAs(UnmanagedType.U4)]
         public uint size;
 
+        // New to v4.5
+        // Flags to control parameters in Brotli-G compression preconditioning
+
+        [MarshalAs(UnmanagedType.U1)]
+        public bool doPreconditionBRLG;
+        [MarshalAs(UnmanagedType.U1)]
+        public bool doDeltaEncodeBRLG;
+        [MarshalAs(UnmanagedType.U1)]
+        public bool doSwizzleBRLG;
+
+        // New to v4.3
+
+        [MarshalAs(UnmanagedType.U4)]
+        public uint pageSize;
+
+        // New to v4.2
+
+        [MarshalAs(UnmanagedType.U1)]
+        public bool useRefinementSteps;
+        [MarshalAs(UnmanagedType.I4)]
+        public int refinementSteps;
+
+        // v4.1 and older settings
+
         [MarshalAs(UnmanagedType.U1)]
         public bool useChannelWeighting;
         [MarshalAs(UnmanagedType.R4)]


### PR DESCRIPTION
Tested, but not extensively. I put this patch together attempting to debug the performance issues with BC7 to no avail, but figured upstreaming wouldn't hurt. Not sure what bases can be covered other than importing images, but I'll test anything that is requested.